### PR TITLE
Fix ClickGUI keybinding and add controls option

### DIFF
--- a/src/main/java/dev/knoxy/rynox/Rynox.java
+++ b/src/main/java/dev/knoxy/rynox/Rynox.java
@@ -1,7 +1,7 @@
 package dev.knoxy.rynox;
 
 import dev.knoxy.rynox.client.gui.ClickGuiScreen;
-import net.fabricmc.api.ModInitializer;
+import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
 import net.fabricmc.fabric.api.client.keybinding.v1.KeyBindingHelper;
 import net.minecraft.client.option.KeyBinding;
@@ -10,7 +10,7 @@ import org.lwjgl.glfw.GLFW;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class Rynox implements ModInitializer {
+public class Rynox implements ClientModInitializer {
     public static final Logger LOGGER = LoggerFactory.getLogger("rynox");
 
     public static final KeyBinding TOGGLE_GUI_KEYBINDING = KeyBindingHelper.registerKeyBinding(new KeyBinding(

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -15,7 +15,7 @@
 
   "environment": "*",
   "entrypoints": {
-    "main": [
+    "client": [
       "dev.knoxy.rynox.Rynox"
     ]
   },


### PR DESCRIPTION
The ClickGUI was not appearing because the keybinding was being initialized in the `main` mod entrypoint, which is for common code. Client-side features like GUIs and keybindings should be initialized in the `client` entrypoint.

This commit changes the mod's entrypoint to `ClientModInitializer` and moves the registration to the `client` entrypoint in `fabric.mod.json`. This makes the keybinding work correctly and adds an option to change it in the controls menu.